### PR TITLE
feat: load toml file

### DIFF
--- a/packages/wrangler/src/index.ts
+++ b/packages/wrangler/src/index.ts
@@ -296,7 +296,12 @@ import { tailCommand } from "./tail";
 import { triggersDeployCommand, triggersNamespace } from "./triggers";
 import { typesCommand } from "./type-generation";
 import { getAuthFromEnv } from "./user";
-import { loginCommand, logoutCommand, whoamiCommand } from "./user/commands";
+import {
+	loadTOMLCommand,
+	loginCommand,
+	logoutCommand,
+	whoamiCommand,
+} from "./user/commands";
 import { whoami } from "./user/whoami";
 import { betaCmdColor, proxy } from "./utils/constants";
 import { debugLogFilepath } from "./utils/log-file";
@@ -1525,6 +1530,14 @@ export function createCLIParser(argv: string[]) {
 		},
 	]);
 	registry.registerNamespace("whoami");
+
+	registry.define([
+		{
+			command: "wrangler load-toml",
+			definition: loadTOMLCommand,
+		},
+	]);
+	registry.registerNamespace("load-toml");
 
 	registry.define([
 		{

--- a/packages/wrangler/src/user/commands.ts
+++ b/packages/wrangler/src/user/commands.ts
@@ -1,6 +1,7 @@
 import { createCommand } from "../core/create-command";
 import { CommandLineArgsError } from "../errors";
 import * as metrics from "../metrics";
+import { loadTOML } from "./load-toml";
 import { listScopes, login, logout, validateScopeKeys } from "./user";
 import { whoami } from "./whoami";
 
@@ -95,6 +96,26 @@ export const logoutCommand = createCommand({
 		metrics.sendMetricsEvent("logout user", {
 			sendMetrics: config.send_metrics,
 		});
+	},
+});
+
+export const loadTOMLCommand = createCommand({
+	metadata: {
+		description: "🔍 Load a TOML file",
+		owner: "Workers: Authoring and Testing",
+		status: "stable",
+	},
+	behaviour: {
+		printConfigWarnings: false,
+	},
+	args: {
+		file: {
+			type: "string",
+			describe: "The TOML file to load",
+		},
+	},
+	async handler(args) {
+		loadTOML(args.file!);
 	},
 });
 

--- a/packages/wrangler/src/user/load-toml.ts
+++ b/packages/wrangler/src/user/load-toml.ts
@@ -1,0 +1,9 @@
+import { logger } from "../logger";
+import { parseTOML, readFileSync } from "../parse";
+import { UserAuthConfig, writeAuthConfigFile } from "./user";
+
+export const loadTOML = (file: string) => {
+	logger.log(`Loading TOML file: ${file}`);
+	const toml = parseTOML(readFileSync(file), file);
+	writeAuthConfigFile(toml as UserAuthConfig);
+};


### PR DESCRIPTION
# Add `load-toml` command to wrangler

This PR adds a new `wrangler load-toml` command that allows users to load a TOML file as their auth configuration. The command takes a file path as an argument, parses the TOML file, and writes it to the auth config file.

---

- Tests
  - [ ] Tests included
  - [x] Tests not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): 
  - [ ] Documentation not necessary because:
- Wrangler V3 Backport
  - [ ] Wrangler PR: 
  - [ ] Not necessary because: